### PR TITLE
辞書の更新と WorkFlow の改善

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,3 +1,5 @@
+# GitHub Actions Workflow: Build and Release All Mozc Dictionaries
+
 name: Build and Release Mozc Dictionary
 
 on:
@@ -21,66 +23,46 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # Download dictionary and required text files
-      - name: Download required text files
+      # Download base dictionary files
+      - name: Download base dictionary files
         run: |
           mkdir -p ./src/main/resources
-          # Download dictionary files
           for i in $(seq -w 00 09); do
             wget https://raw.githubusercontent.com/google/mozc/master/src/data/dictionary_oss/dictionary${i}.txt -O ./src/main/resources/dictionary${i}.txt
           done
-          # Download additional files from dictionary_oss
           wget https://raw.githubusercontent.com/google/mozc/master/src/data/dictionary_oss/connection_single_column.txt -O ./src/main/resources/connection_single_column.txt
           wget https://raw.githubusercontent.com/google/mozc/master/src/data/dictionary_oss/suffix.txt -O ./src/main/resources/suffix.txt
-          # Download single_kanji.tsv from the single_kanji directory
           wget https://raw.githubusercontent.com/google/mozc/master/src/data/single_kanji/single_kanji.tsv -O ./src/main/resources/single_kanji.tsv
 
       # Build the project with Gradle
       - name: Build with Gradle
         run: ./gradlew build
 
-      # Run the Kotlin application
+      # --- Run all dictionary creation tasks ---
       - name: Run main.kt
         run: ./gradlew run
 
-      # Upload artifacts to GitHub Actions
-      - name: Upload artifacts (Mozc)
-        uses: actions/upload-artifact@v4
-        with:
-          name: mozc-dictionary-artifacts  # Unique name to prevent overwrite
-          path: |
-            ./src/main/resources/connectionId.dat
-            ./src/main/resources/pos_table.dat
-            ./src/main/resources/yomi_singleKanji.dat
-            ./src/main/resources/tango_singleKanji.dat
-            ./src/main/resources/token_singleKanji.dat
-            ./src/main/resources/yomi.dat
-            ./src/main/resources/tango.dat
-            ./src/main/resources/token.dat
-            ./src/main/resources/yomi_emoji.dat
-            ./src/main/resources/tango_emoji.dat
-            ./src/main/resources/token_emoji.dat
-            ./src/main/resources/yomi_emoticon.dat
-            ./src/main/resources/tango_emoticon.dat
-            ./src/main/resources/token_emoticon.dat
-            ./src/main/resources/yomi_symbol.dat
-            ./src/main/resources/tango_symbol.dat
-            ./src/main/resources/token_symbol.dat
-            ./src/main/resources/yomi_reading_correction.dat
-            ./src/main/resources/tango_reading_correction.dat
-            ./src/main/resources/token_reading_correction.dat
-            ./src/main/resources/yomi_kotowaza.dat
-            ./src/main/resources/tango_kotowaza.dat
-            ./src/main/resources/token_kotowaza.dat
+      - name: Run MozcUT.kt (Person Names, Places)
+        run: ./gradlew runMozcUT
 
-      # Create a GitHub Release and upload artifacts
-      - name: Create GitHub Release (Mozc)
+      - name: Run MozcUTWiki.kt (Wikipedia)
+        run: ./gradlew runMozcUTWiki
+
+      - name: Run MozcUTNeologd.kt (NEologd)
+        run: ./gradlew runMozcUTNeologd
+
+      - name: Run MozcUTWikiNeologdCommon.kt (Web)
+        run: ./gradlew runMozcUTWikiNeologdCommon
+
+      # --- Create a single release with all generated artifacts ---
+      - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
           name: Release ${{ github.ref }}
           artifacts: |
+            # --- Artifacts from main.kt ---
             ./src/main/resources/connectionId.dat
             ./src/main/resources/pos_table.dat
             ./src/main/resources/yomi_singleKanji.dat
@@ -104,4 +86,27 @@ jobs:
             ./src/main/resources/yomi_kotowaza.dat
             ./src/main/resources/tango_kotowaza.dat
             ./src/main/resources/token_kotowaza.dat
-          replacesArtifacts: false  # Prevent overwriting
+            
+            # --- Artifacts from MozcUT.kt ---
+            ./src/main/resources/yomi_person_names.dat
+            ./src/main/resources/tango_person_names.dat
+            ./src/main/resources/token_person_names.dat
+            ./src/main/resources/yomi_places.dat
+            ./src/main/resources/tango_places.dat
+            ./src/main/resources/token_places.dat
+            
+            # --- Artifacts from MozcUTWiki.kt ---
+            ./src/main/resources/yomi_wiki.dat
+            ./src/main/resources/tango_wiki.dat
+            ./src/main/resources/token_wiki.dat
+
+            # --- Artifacts from MozcUTNeologd.kt ---
+            ./src/main/resources/yomi_neologd.dat
+            ./src/main/resources/tango_neologd.dat
+            ./src/main/resources/token_neologd.dat
+            
+            # --- Artifacts from MozcUTWikiNeologdCommon.kt ---
+            ./src/main/resources/yomi_web.dat
+            ./src/main/resources/tango_web.dat
+            ./src/main/resources/token_web.dat
+          replacesArtifacts: false

--- a/src/main/kotlin/Constants.kt
+++ b/src/main/kotlin/Constants.kt
@@ -6,378 +6,378 @@ object Constants {
     val DIC_LIST = listOf(
         Dictionary(
             yomi = "a",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "a"
         ),
         Dictionary(
             yomi = "b",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "b"
         ),
         Dictionary(
             yomi = "c",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "c"
         ),
         Dictionary(
             yomi = "d",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "d"
         ),
         Dictionary(
             yomi = "e",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "e"
         ),
         Dictionary(
             yomi = "f",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "f"
         ),
         Dictionary(
             yomi = "g",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "g"
         ),
         Dictionary(
             yomi = "h",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "h"
         ),
         Dictionary(
             yomi = "i",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "i"
         ),
         Dictionary(
             yomi = "j",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "j"
         ),
         Dictionary(
             yomi = "k",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "k"
         ),
         Dictionary(
             yomi = "l",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "l"
         ),
         Dictionary(
             yomi = "m",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "m"
         ),
         Dictionary(
             yomi = "n",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "n"
         ),
         Dictionary(
             yomi = "o",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "o"
         ),
         Dictionary(
             yomi = "p",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "p"
         ),
         Dictionary(
             yomi = "q",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "q"
         ),
         Dictionary(
             yomi = "r",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "r"
         ),
         Dictionary(
             yomi = "s",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "s"
         ),
         Dictionary(
             yomi = "t",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "t"
         ),
         Dictionary(
             yomi = "u",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "u"
         ),
         Dictionary(
             yomi = "v",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "v"
         ),
         Dictionary(
             yomi = "x",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "x"
         ),
         Dictionary(
             yomi = "y",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "y"
         ),
         Dictionary(
             yomi = "z",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "z"
         ),
         Dictionary(
             yomi = "A",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "A"
         ),
         Dictionary(
             yomi = "B",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "B"
         ),
         Dictionary(
             yomi = "C",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "C"
         ),
         Dictionary(
             yomi = "D",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "D"
         ),
         Dictionary(
             yomi = "E",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "E"
         ),
         Dictionary(
             yomi = "F",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "F"
         ),
         Dictionary(
             yomi = "G",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "G"
         ),
         Dictionary(
             yomi = "H",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "H"
         ),
         Dictionary(
             yomi = "I",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "I"
         ),
         Dictionary(
             yomi = "J",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "J"
         ),
         Dictionary(
             yomi = "K",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "K"
         ),
         Dictionary(
             yomi = "L",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "L"
         ),
         Dictionary(
             yomi = "M",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "M"
         ),
         Dictionary(
             yomi = "N",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "N"
         ),
         Dictionary(
             yomi = "O",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "O"
         ),
         Dictionary(
             yomi = "P",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "P"
         ),
         Dictionary(
             yomi = "Q",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "Q"
         ),
         Dictionary(
             yomi = "R",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "R"
         ),
         Dictionary(
             yomi = "S",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "S"
         ),
         Dictionary(
             yomi = "T",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "T"
         ),
         Dictionary(
             yomi = "U",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "U"
         ),
         Dictionary(
             yomi = "V",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "V"
         ),
         Dictionary(
             yomi = "W",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "W"
         ),
         Dictionary(
             yomi = "X",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "X"
         ),
         Dictionary(
             yomi = "Y",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "Y"
         ),
         Dictionary(
             yomi = "Z",
-            leftId = 2640,
-            rightId = 2640,
+            leftId = 1851,
+            rightId = 2641,
             cost = 8000,
             tango = "Z"
         ),
         Dictionary(
             yomi = "'",
-            leftId = 2655,
+            leftId = 1851,
             rightId = 2655,
             cost = 8000,
             tango = "'"
         ),
         Dictionary(
             yomi = "~",
-            leftId = 2651,
+            leftId = 1851,
             rightId = 2651,
             cost = 8000,
             tango = "~"
         ),
         Dictionary(
             yomi = "\"",
-            leftId = 2654,
+            leftId = 1851,
             rightId = 2654,
             cost = 8000,
             tango = "\""
@@ -461,91 +461,91 @@ object Constants {
         ),
         Dictionary(
             yomi = "%",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "%"
         ),
         Dictionary(
             yomi = "°",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "°"
         ),
         Dictionary(
             yomi = "￥",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "￥"
         ),
         Dictionary(
             yomi = "€",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "€"
         ),
         Dictionary(
             yomi = "♪",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "♪"
         ),
         Dictionary(
             yomi = "々",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "々"
         ),
         Dictionary(
             yomi = "#",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "#"
         ),
         Dictionary(
             yomi = "&",
-            leftId = 2641,
+            leftId = 1851,
             rightId = 2641,
             cost = 8000,
             tango = "&"
         ),
         Dictionary(
             yomi = "！",
-            leftId = 2642,
+            leftId = 1851,
             rightId = 2642,
             cost = 8000,
             tango = "！"
         ),
         Dictionary(
             yomi = "〜",
-            leftId = 2651,
+            leftId = 1851,
             rightId = 2651,
             cost = 8000,
             tango = "〜"
         ),
         Dictionary(
             yomi = "？",
-            leftId = 2645,
+            leftId = 1851,
             rightId = 2645,
             cost = 8000,
             tango = "？"
         ),
         Dictionary(
             yomi = "（",
-            leftId = 2653,
+            leftId = 1851,
             rightId = 2653,
             cost = 8000,
             tango = "（"
         ),
         Dictionary(
             yomi = "）",
-            leftId = 2652,
+            leftId = 1851,
             rightId = 2652,
             cost = 8000,
             tango = "）"
@@ -1816,6 +1816,13 @@ object Constants {
             tango = "不可視化"
         ),
         Dictionary(
+            yomi = "何度か",
+            leftId = 12,
+            rightId = 12,
+            cost = 3500,
+            tango = "不可視化"
+        ),
+        Dictionary(
             yomi = "じぇみに",
             leftId = 1920,
             rightId = 1920,
@@ -1828,6 +1835,62 @@ object Constants {
             rightId = 1851,
             cost = 4000,
             tango = "欺罔行為"
+        ),
+        Dictionary(
+            yomi = "ききました",
+            leftId = 260,
+            rightId = 727,
+            cost = 1000,
+            tango = "聞きました"
+        ),
+        Dictionary(
+            yomi = "ききました",
+            leftId = 260,
+            rightId = 727,
+            cost = 1005,
+            tango = "効きました"
+        ),
+        Dictionary(
+            yomi = "ききました",
+            leftId = 260,
+            rightId = 727,
+            cost = 1010,
+            tango = "聴きました"
+        ),
+        Dictionary(
+            yomi = "こわすぎ",
+            leftId = 2391,
+            rightId = 1949,
+            cost = 4800,
+            tango = "怖すぎ"
+        ),
+        Dictionary(
+            yomi = "かちかく",
+            leftId = 1851,
+            rightId = 1841,
+            cost = 3500,
+            tango = "勝ち確"
+        ),
+        Dictionary(
+            yomi = "からもじ",
+            leftId = 1851,
+            rightId = 1851,
+            cost = 3500,
+            tango = "空文字"
+        ),
+        Dictionary(
+            yomi = "まじりぶん",
+            leftId = 1851,
+            rightId = 1841,
+            cost = 3500,
+            tango = "交じり文"
+        ),
+        Dictionary(
+            yomi = "りけん",
+            leftId = 1851,
+            rightId = 1841,
+            cost = 5000,
+            tango = "離鍵"
         ),
     )
 

--- a/src/main/kotlin/dictionary/DicUtils.kt
+++ b/src/main/kotlin/dictionary/DicUtils.kt
@@ -198,6 +198,10 @@ class DicUtils {
                             println("skip $yomi $tango")
                         }
 
+                        yomi == "ようけんどう" && tango == "明倫養賢堂" -> {
+                            println("skip $yomi $tango")
+                        }
+
                         yomi == "りょうしか" && tango == "量子化" -> {
                             println("skip $yomi $tango")
                         }
@@ -235,6 +239,10 @@ class DicUtils {
                         }
 
                         yomi == "か" && tango == "化" && leftId == "1941" && rightId == "1941" -> {
+                            println("skip $yomi $tango")
+                        }
+
+                        yomi == "こわすぎ" && tango == "怖すぎ" && leftId == "2391" && rightId == "1949" -> {
                             println("skip $yomi $tango")
                         }
 


### PR DESCRIPTION
## 概要
以下の単語を追加した
- 勝ち確
- 離鍵
- 空文字
- 交じり文

以下の単語のスコアを修正した
- 強すぎ
- ききました
- 何度か