### PR TITLE
変体仮名のノード id の修正

### DIFF
--- a/src/main/kotlin/Extenstions.kt
+++ b/src/main/kotlin/Extenstions.kt
@@ -245,19 +245,19 @@ fun normalizeHiragana(input: String): String {
 
 fun String.isHiraganaOrKatakana(): Boolean {
     // Exclude ゝ (U+309D) and ゞ (U+309E) from Hiragana, and ヽ (U+30FD) and ヾ (U+30FE) from Katakana
-    val hiraganaRegex = Regex("^[\\u3040-\\u309F&&[^\\u309D\\u309E]]+$")
-    val katakanaRegex = Regex("^[\\u30A0-\\u30FF&&[^\\u30FD\\u30FE]]+$")
+    val hiraganaRegex = Regex("^\\u3041-\\u3096&&[^\\u3090\\u3091]+$")
+    val katakanaRegex = Regex("^\\u30A1-\\u30FF&&[^\\u30F0\\u30F1\\u30F7-\\u30FA\\u30FD\\u30FE]+$")
     return hiraganaRegex.matches(this) || katakanaRegex.matches(this)
 }
 
 fun String.isHiraganaOnly(): Boolean {
     // Exclude ゝ (U+309D) and ゞ (U+309E) from Hiragana
-    val regex = Regex("^[\\u3040-\\u309F&&[^\\u309D\\u309E]]+$")
+    val regex = Regex("^\\u3041-\\u3096&&[^\\u3090\\u3091]+$")
     return regex.matches(this)
 }
 
 fun String.isKatakanaOnly(): Boolean {
     // Exclude ヽ (U+30FD) and ヾ (U+30FE) from Katakana
-    val regex = Regex("^[\\u30A0-\\u30FF&&[^\\u30FD\\u30FE]]+$")
+    val regex = Regex("^\\u30A1-\\u30FF&&[^\\u30F0\\u30F1\\u30F7-\\u30FA\\u30FD\\u30FE]+$")
     return regex.matches(this)
 }

--- a/src/main/kotlin/dictionary/TokenArray.kt
+++ b/src/main/kotlin/dictionary/TokenArray.kt
@@ -60,6 +60,10 @@ class TokenArray {
                     println("build token array: $index $key ${dictionary.tango} $nodeId")
                 } else if (key == "こころ") {
                     println("build token array: $index $key ${dictionary.tango} $nodeId")
+                } else if (key == "うぇ") {
+                    println("build token array: $index $key ${dictionary.tango} $nodeId")
+                } else if (key == "なかぐろ") {
+                    println("build token array: $index $key ${dictionary.tango} $nodeId")
                 }
                 nodeIdList.add(nodeId)
             }

--- a/src/test/kotlin/symbol/SymbolDictionaryBuilderTest.kt
+++ b/src/test/kotlin/symbol/SymbolDictionaryBuilderTest.kt
@@ -22,6 +22,7 @@ class SymbolDictionaryBuilderTest {
             println("${dictionaries.filter { it.tango == "\"" }}")
             println("${dictionaries.filter { it.tango == "\'" }}")
             println("${dictionaries.filter { it.tango == "”" }}")
+            println("${dictionaries.filter { it.tango == "ヱ" }}")
         }
 
     }


### PR DESCRIPTION
ヱ、ゑ などの判定の修正